### PR TITLE
Updates for deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run testServer

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "author": "AlmostGreatBand",
   "devDependencies": {
     "eslint": "^7.17.0"
+  },
+  "engines": {
+    "node": "14.x"
   }
 }

--- a/set-up.sh
+++ b/set-up.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
-git config core.hooksPath ./.github/hooks
-echo "Current hooks path is:"
-git config --get core.hooksPath
+inside_git_repo="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
+if [ "$inside_git_repo" ]; then
+    git config core.hooksPath ./.github/hooks 2>&1
+    echo "Current hooks path is:"
+    git config --get core.hooksPath 2>&1
+else
+    echo "Hooks not set as you're not in git repo"
+fi
+


### PR DESCRIPTION
I've made some updates to automate deployment process. 

Server now runs on the given port or defaut (8000). If it detects ssl certificates in root directory, it uses them and enables HTTPS protocol. Otherwise, it uses HTTP protocol. For the purposes of debugging he also prints to console which port, protocol and host he's using.

Close #18